### PR TITLE
refactor(tsc-wrapped):  change from NodeFlags to ModifierFlags

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -75,16 +75,16 @@ export class MetadataCollector {
 
 
     interface NodeFlagsUtils {
-      getNodeFlags(flag: ts.NodeFlags): (target: ts.Node) => boolean;
+      getNodeFlags(flag: ts.ModifierFlags): (target: ts.Node) => boolean;
     }
 
     const nodeFlagsUtils = {
-      get isStatic(this: NodeFlagsUtils) { return this.getNodeFlags(ts.NodeFlags.Static); },
+      get isStatic(this: NodeFlagsUtils) { return this.getNodeFlags(ts.ModifierFlags.Static); },
 
-      get isExport(this: NodeFlagsUtils) { return this.getNodeFlags(ts.NodeFlags.Export); },
+      get isExport(this: NodeFlagsUtils) { return this.getNodeFlags(ts.ModifierFlags.Export); },
 
-      getNodeFlags(flag: ts.NodeFlags) {
-        return function(target: ts.Node) { return !!(target.flags & flag); };
+      getNodeFlags(flag: ts.ModifierFlags) {
+        return function(target: ts.Node) { return !!(ts.getCombinedModifierFlags(target) & flag); };
       },
     };
 


### PR DESCRIPTION
TypeScript v2.1 separates modifier related flags into `ModifierFlags` (commits: [5b8cf9](https://git.io/v1TIX)).